### PR TITLE
Loading indicators when date navigation happens

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -12,7 +12,7 @@ import { MatInputModule } from '@angular/material/input';
 import { MatSelectModule } from '@angular/material/select';
 import { MatGridListModule } from '@angular/material/grid-list';
 import { MatSnackBarModule } from '@angular/material/snack-bar';
-
+import { MatProgressBarModule } from '@angular/material/progress-bar';
 
 
 // Components
@@ -29,6 +29,7 @@ import { EventProviderService } from './event-provider.service';
 import { GoogleSigninComponent } from './google-signin/google-signin.component';
 import { LoginPersistanceService } from './login-persistance.service';
 import { CalendarQueryBuilderService } from './calendar-query-builder.service';
+import { OperationIndicationService } from './operation-indication.service';
 @NgModule({
   declarations: [
     AppComponent,
@@ -55,11 +56,13 @@ import { CalendarQueryBuilderService } from './calendar-query-builder.service';
     MatSelectModule,
     MatGridListModule,
     MatSnackBarModule,
+    MatProgressBarModule,
   ],
   providers: [
     EventProviderService,
     LoginPersistanceService,
     CalendarQueryBuilderService,
+    OperationIndicationService,
   ],
   bootstrap: [AppComponent]
 })

--- a/src/app/day-view/day-view.component.ts
+++ b/src/app/day-view/day-view.component.ts
@@ -89,7 +89,10 @@ export class DayViewComponent implements OnInit {
 
   private subscribeToDateSelection() {
     this.calenderActionsService.dateSetAction$.subscribe((selectedDate: moment.Moment) => {
+      this.operationIndicator.loading();
       this.onDayChanged(selectedDate);
+      // refresh events for that day.
+      this.queryCalendar(NavigationDirection.DATE_SELECTION);
     });
   }
 

--- a/src/app/day-view/day-view.component.ts
+++ b/src/app/day-view/day-view.component.ts
@@ -5,6 +5,7 @@ import { CalendarActionsService } from '../calendar-actions.service';
 import { NavigationDirection } from 'src/config/navigation-direction';
 import { CalendarQueryBuilderService } from '../calendar-query-builder.service';
 import { ViewTypes } from 'src/config/view-type';
+import { OperationIndicationService } from '../operation-indication.service';
 @Component({
   selector: 'app-day-view',
   templateUrl: './day-view.component.html',
@@ -22,6 +23,7 @@ export class DayViewComponent implements OnInit {
     private eventProviderService: EventProviderService,
     private calenderActionsService: CalendarActionsService,
     private calendarQueryBuilder: CalendarQueryBuilderService,
+    private operationIndicator: OperationIndicationService,
   ) {
     this.setDateVariables();
   }
@@ -65,6 +67,9 @@ export class DayViewComponent implements OnInit {
       // FIXME: the logic for calculating new dates is repeated in CalendarQuerybuilder and here.
       // TODO: refactor them into a util or something.
 
+      // set the loading state
+      this.operationIndicator.loading();
+
       let newDate = null;
       if (direction === NavigationDirection.NEXT) {
         newDate = moment(this.currentDateTime).add(1, 'day');
@@ -90,6 +95,7 @@ export class DayViewComponent implements OnInit {
 
   private subscribeToEventsRefreshed() {
     this.eventProviderService.eventsRefreshed$.subscribe((events: []) => {
+      this.operationIndicator.complete();
       this.processEvents(events);
     });
   }

--- a/src/app/main/main.component.html
+++ b/src/app/main/main.component.html
@@ -1,3 +1,8 @@
 <div class="calendar">
+  <mat-progress-bar *ngIf="loading"
+    color="accent"
+    mode="indeterminate"
+  >
+  </mat-progress-bar>
   <app-day-view></app-day-view>
 </div>

--- a/src/app/main/main.component.ts
+++ b/src/app/main/main.component.ts
@@ -1,4 +1,5 @@
 import { Component, OnInit } from '@angular/core';
+import { OperationIndicationService } from '../operation-indication.service';
 
 @Component({
   selector: 'app-main',
@@ -6,10 +7,13 @@ import { Component, OnInit } from '@angular/core';
   styleUrls: ['./main.component.sass']
 })
 export class MainComponent implements OnInit {
-
-  constructor() { }
+  loading = false;
+  constructor(private operationIndicator: OperationIndicationService) { }
 
   ngOnInit(): void {
+    this.operationIndicator.requestInFlight$.subscribe((isInFlight: boolean) => {
+      this.loading = isInFlight;
+    });
   }
 
 }

--- a/src/app/operation-indication.service.spec.ts
+++ b/src/app/operation-indication.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { OperationIndicationService } from './operation-indication.service';
+
+describe('OperationIndicationService', () => {
+  let service: OperationIndicationService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(OperationIndicationService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/operation-indication.service.ts
+++ b/src/app/operation-indication.service.ts
@@ -1,0 +1,24 @@
+import { Injectable } from '@angular/core';
+import { Subject } from 'rxjs';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class OperationIndicationService {
+  isLoading = false;
+  requestInflightSource = new Subject<boolean>();
+  requestInFlight$ = this.requestInflightSource.asObservable();
+
+  constructor() { }
+
+  loading() {
+    this.isLoading = true;
+    this.requestInflightSource.next(true);
+  }
+
+  complete() {
+    this.isLoading = false;
+    this.requestInflightSource.next(false);
+  }
+
+}

--- a/src/config/navigation-direction.ts
+++ b/src/config/navigation-direction.ts
@@ -2,4 +2,5 @@ export enum NavigationDirection {
   NEXT,
   PREV,
   TODAY,
+  DATE_SELECTION,
 }


### PR DESCRIPTION
Things are Not ideal right now, as on every date navigation I make a server trip.
However, it works for now. 

An Ideal approach would be to prefetch Date + 10, and Date - 10 events mapped to their date. 
This cache could be like a sliding window which always maintains  2*(window size) + 1 items.